### PR TITLE
Bumping Cake.Core to 16.0.2

### DIFF
--- a/src/Cake.EntityFramework6/packages.config
+++ b/src/Cake.EntityFramework6/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.15.2" targetFramework="net452" />
+  <package id="Cake.Core" version="0.16.2" targetFramework="net45" />
   <package id="Costura.Fody" version="1.3.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Fody" version="1.28.3" targetFramework="net45" developmentDependency="true" />


### PR DESCRIPTION
Required to work with latest version of Cake. #6 

The targetFramework change is weird to me - it looks like `Cake.EntityFramework6` is .NET 4.5, and the dependency was somehow pointing at 4.5.2. We could change this project to 4.5.2, or we could manually undo that edit, or just leave it as is in this pull request.