### PR TITLE
Allow data loss on migrations

### DIFF
--- a/src/Cake.EntityFramework6/CakeTranslation/Ef6Aliases.cs
+++ b/src/Cake.EntityFramework6/CakeTranslation/Ef6Aliases.cs
@@ -72,8 +72,9 @@ namespace Cake.EntityFramework6.CakeTranslation
                 settings.AppConfigPath.FullPath,
                 settings.ConnectionString,
                 settings.ConnectionProvider,
-                new CakeLogger(context.Log)
-            );
+                new CakeLogger(context.Log),
+                settings.AllowDataLossOnMigrations
+                );
         }
     }
 }

--- a/src/Cake.EntityFramework6/CakeTranslation/EfMigratorSettings.cs
+++ b/src/Cake.EntityFramework6/CakeTranslation/EfMigratorSettings.cs
@@ -46,5 +46,11 @@ namespace Cake.EntityFramework6.CakeTranslation
         /// The connection provider to be used for code-first migrations.
         /// </value>
         public string ConnectionProvider { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag to allow data to be lost on a migration.
+        /// This is the same as the '-force' flag when running migrations through visual studio.
+        /// </summary>
+        public bool AllowDataLossOnMigrations { get; set; }
     }
 }

--- a/src/Cake.EntityFramework6/Migrator/EfMigrator.cs
+++ b/src/Cake.EntityFramework6/Migrator/EfMigrator.cs
@@ -22,7 +22,7 @@ namespace Cake.EntityFramework6.Migrator
         public string CurrentMigration { get; private set; }
 
         public EfMigrator(string assemblyPath, string qualifiedDbConfigName, string appConfigPath, string connectionString, string connectionProvider,
-                          ILogger logger)
+                          ILogger logger, bool allowDataLossOnMigrations)
         {
             _logger = logger;
 
@@ -63,6 +63,8 @@ namespace Cake.EntityFramework6.Migrator
             CurrentMigration = migrator.GetCurrentMigration() ?? InitialDatabase;
             var currentMigrationStr = CurrentMigration == InitialDatabase ? "$InitialDatabase" : CurrentMigration;
             _logger.Information($"Current Migration is {currentMigrationStr}.");
+
+            migrator.SetAllowDataLossOnMigrations(allowDataLossOnMigrations);
 
             _migratorBackend = migrator;
         }

--- a/src/Cake.EntityFramework6/Migrator/EfMigratorBackend.cs
+++ b/src/Cake.EntityFramework6/Migrator/EfMigratorBackend.cs
@@ -79,6 +79,11 @@ namespace Cake.EntityFramework6.Migrator
             return new MigrationResult(true);
         }
 
+        public void SetAllowDataLossOnMigrations(bool allowDataLossOnMigrations)
+        {
+            _dbMigrator.Configuration.AutomaticMigrationDataLossAllowed = allowDataLossOnMigrations;
+        }
+
         public void Initialize(string assemblyPath, string qualifiedDbConfigName, string connectionString, string connectionProvider)
         {
             if (Ready)

--- a/tests/Cake.EntityFramework6.Tests/Migrator/GenericMigratorFacts.cs
+++ b/tests/Cake.EntityFramework6.Tests/Migrator/GenericMigratorFacts.cs
@@ -32,7 +32,7 @@ namespace Cake.EntityFramework6.Tests.Migrator
         public void When_appConfig_path_should_not_exist_throw()
         {
             var appPath = AutoFixture.Create<string>();
-            Action action = () => new EfMigrator(null, null, appPath, null, null, _mockLogger);
+            Action action = () => new EfMigrator(null, null, appPath, null, null, _mockLogger, false);
 
             // Act
 
@@ -46,7 +46,7 @@ namespace Cake.EntityFramework6.Tests.Migrator
         {
             var appPath = PostgresFactConstants.AppConfig;
             var assemblyPath = AutoFixture.Create<string>();
-            Action action = () => new EfMigrator(assemblyPath, null, appPath, null, null, _mockLogger);
+            Action action = () => new EfMigrator(assemblyPath, null, appPath, null, null, _mockLogger, false);
 
             // Act
 
@@ -61,7 +61,7 @@ namespace Cake.EntityFramework6.Tests.Migrator
             var appPath = PostgresFactConstants.AppConfig;
             var assemblyPath = PostgresFactConstants.DdlPath;
             var dbConfig = AutoFixture.Create<string>();
-            Action action = () => new EfMigrator(assemblyPath, dbConfig, appPath, null, null, _mockLogger);
+            Action action = () => new EfMigrator(assemblyPath, dbConfig, appPath, null, null, _mockLogger, false);
 
             // Act
 
@@ -78,7 +78,7 @@ namespace Cake.EntityFramework6.Tests.Migrator
             var dbConfig = PostgresFactConstants.ConfigName;
             var connectionString = AutoFixture.Create<string>();
             var providerName = PostgresFactConstants.ConnectionProvider;
-            Action action = () => new EfMigrator(assemblyPath, dbConfig, appPath, connectionString, providerName, _mockLogger);
+            Action action = () => new EfMigrator(assemblyPath, dbConfig, appPath, connectionString, providerName, _mockLogger, false);
 
             // Act
 

--- a/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/CurrentMigrationFacts.cs
+++ b/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/CurrentMigrationFacts.cs
@@ -20,7 +20,7 @@ namespace Cake.EntityFramework6.Tests.Migrator.Postgres
         private readonly string _instanceString = PostgresFactConstants.InstanceConnectionString;
 
         private IEfMigrator Migrator => new EfMigrator(PostgresFactConstants.DdlPath, PostgresFactConstants.ConfigName, PostgresFactConstants.AppConfig,
-            _instanceString, PostgresFactConstants.ConnectionProvider, _mockLogger);
+            _instanceString, PostgresFactConstants.ConnectionProvider, _mockLogger, false);
 
         public CurrentMigrationFacts(ITestOutputHelper logHelper)
         {

--- a/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/LocalMigrationFacts.cs
+++ b/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/LocalMigrationFacts.cs
@@ -24,7 +24,7 @@ namespace Cake.EntityFramework6.Tests.Migrator.Postgres
             _logHelper = logHelper;
             _mockLogger = new MockLogger(logHelper);
             _migrator = new EfMigrator(PostgresFactConstants.DdlPath, PostgresFactConstants.ConfigName, PostgresFactConstants.AppConfig,
-                PostgresFactConstants.InstanceConnectionString, PostgresFactConstants.ConnectionProvider, _mockLogger);
+                PostgresFactConstants.InstanceConnectionString, PostgresFactConstants.ConnectionProvider, _mockLogger, false);
         }
 
         [Fact]

--- a/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/MigratorFacts.cs
+++ b/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/MigratorFacts.cs
@@ -21,7 +21,7 @@ namespace Cake.EntityFramework6.Tests.Migrator.Postgres
         private readonly string _instanceString = PostgresFactConstants.InstanceConnectionString;
 
         private IEfMigrator Migrator => new EfMigrator(PostgresFactConstants.DdlPath, PostgresFactConstants.ConfigName, PostgresFactConstants.AppConfig,
-            _instanceString, PostgresFactConstants.ConnectionProvider, _mockLogger);
+            _instanceString, PostgresFactConstants.ConnectionProvider, _mockLogger, false);
 
         public MigratorFacts(ITestOutputHelper logHelper)
         {

--- a/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/RemoteMigrationsFacts.cs
+++ b/tests/Cake.EntityFramework6.Tests/Migrator/Postgres/RemoteMigrationsFacts.cs
@@ -24,7 +24,7 @@ namespace Cake.EntityFramework6.Tests.Migrator.Postgres
             _logHelper = logHelper;
             _mockLogger = new MockLogger(logHelper);
             _migrator = new EfMigrator(PostgresFactConstants.DdlPath, PostgresFactConstants.ConfigName, PostgresFactConstants.AppConfig,
-                PostgresFactConstants.InstanceConnectionString, PostgresFactConstants.ConnectionProvider, _mockLogger);
+                PostgresFactConstants.InstanceConnectionString, PostgresFactConstants.ConnectionProvider, _mockLogger, false);
         }
 
         [Fact]


### PR DESCRIPTION
Added the ability to allow migrations to lose data  #7 . This is done via the Ef Migrator Settings.

This may not be the long-term way we want to expose this feature, but this is something I need in order to dogfood this tool sooner rather than later.