### PR TITLE
Loading connection string & provider through app config

### DIFF
--- a/src/Cake.EntityFramework6/CakeTranslation/EfMigratorSettings.cs
+++ b/src/Cake.EntityFramework6/CakeTranslation/EfMigratorSettings.cs
@@ -46,5 +46,11 @@ namespace Cake.EntityFramework6.CakeTranslation
         /// The connection provider to be used for code-first migrations.
         /// </value>
         public string ConnectionProvider { get; set; }
+
+        /// <summary>
+        /// The name of the connection string in the configuration file.
+        /// This can be used to load the connection string and provider.
+        /// </summary>
+        public string ConnectionName { get; set; }
     }
 }

--- a/tests/Cake.EntityFramework6.Tests/CakeAliases/Ef6AliasesFacts.cs
+++ b/tests/Cake.EntityFramework6.Tests/CakeAliases/Ef6AliasesFacts.cs
@@ -30,7 +30,7 @@ namespace Cake.EntityFramework6.Tests.CakeAliases
             new object[] {Expression(x => x.AppConfigPath)},
             new object[] {Expression(x => x.AssemblyPath)},
             new object[] {Expression(x => x.ConfigurationClass)},
-            new object[] {Expression(x => x.ConnectionProvider)},
+            new object[] {Expression(x => x.ConnectionProvider)},            
             new object[] {Expression(x => x.ConnectionString)},
         };
 
@@ -39,6 +39,7 @@ namespace Cake.EntityFramework6.Tests.CakeAliases
         {
             var settings = AutoFixture.Build<EfMigratorSettings>()
                                       .With(expression, null)
+                                      .With(x => x.ConnectionName, null)
                                       .Create();
 
             // Act

--- a/tests/Cake.EntityFramework6.Tests/CakeAliases/Ef6AliasesFacts.cs
+++ b/tests/Cake.EntityFramework6.Tests/CakeAliases/Ef6AliasesFacts.cs
@@ -75,6 +75,21 @@ namespace Cake.EntityFramework6.Tests.CakeAliases
             action.ShouldThrow<ArgumentException>();
         }
 
+        [Fact]
+        public void Missing_App_Config_Throws()
+        {
+            var settings = AutoFixture.Build<EfMigratorSettings>()
+                                      .With(x => x.ConnectionString, null)
+                                      .With(x => x.ConnectionProvider, null)
+                                      .Create();
+
+            // Act
+            Action action = () => _context.CreateEfMigrator(settings);
+
+            // Assert
+            action.ShouldThrow<ArgumentException>();
+        }
+
         private static Expression<Func<EfMigratorSettings, object>> Expression(Expression<Func<EfMigratorSettings, object>> expression)
         {
             return expression;


### PR DESCRIPTION
#4 

Adding this primarily for code review & discussion - I want to build a more useful integration test with a config but I want some input on the best way to go about that. Similarly, I feel like I shoehorned the actual value loading into the wrong file.

This feature is pretty important to me for the sanity of not having to maintain connection string information in multiple locations. 

Some topics for discussion: 
- Exception types thrown when loading values through app config fails - I did Invalid for now but I'm open to change it.
- How to best unit test (integration test?) this with an app config with invalid values.
- If the poorly-named `SetConnectionStringFromAppConfig` function should stay where it is, or if we want to move that somewhere else.