### PR TITLE
[WIP] Adding RunSeedMethod Function

### DIFF
--- a/src/Cake.EntityFramework/Interfaces/IEfMigrator.cs
+++ b/src/Cake.EntityFramework/Interfaces/IEfMigrator.cs
@@ -90,5 +90,10 @@ namespace Cake.EntityFramework.Interfaces
         /// </summary>
         /// <returns>true if script generation was successful, otherwise false</returns>
         string GenerateScriptForLatest();
+
+        /// <summary>
+        /// Runs the Seed Method
+        /// </summary>
+        void RunSeedMethod();
     }
 }

--- a/src/Cake.EntityFramework/Interfaces/IEfMigratorBackend.cs
+++ b/src/Cake.EntityFramework/Interfaces/IEfMigratorBackend.cs
@@ -76,5 +76,11 @@ namespace Cake.EntityFramework.Interfaces
         /// </summary>
         /// <returns>Latest migration name</returns>
         string GetLatestMigration();
+
+        /// <summary>
+        /// Runs the seed method on the target database.
+        /// </summary>
+        /// <returns></returns>
+        void RunSeedMethod();
     }
 }

--- a/src/Cake.EntityFramework/Migrator/EfMigrator.cs
+++ b/src/Cake.EntityFramework/Migrator/EfMigrator.cs
@@ -257,5 +257,13 @@ namespace Cake.EntityFramework.Migrator
             
             return result.Script;
         }
+
+        /// <summary>
+        /// Runs the Seed Method on the targeted database.
+        /// </summary>
+        public void RunSeedMethod()
+        {            
+            _migratorBackend.RunSeedMethod();
+        }
     }
 }

--- a/src/Cake.EntityFramework/Migrator/EfMigratorBackend.cs
+++ b/src/Cake.EntityFramework/Migrator/EfMigratorBackend.cs
@@ -74,6 +74,15 @@ namespace Cake.EntityFramework.Migrator
         }
 
         /// <summary>
+        /// Updates the database to the current database version and runs the seed method. This should result in no schema changes.
+        /// </summary>
+        public void RunSeedMethod()
+        {
+            var current = GetCurrentMigration();
+            MigrateTo(current);
+        }
+
+        /// <summary>
         /// Determines if there are any pending migrations
         /// </summary>
         /// <returns>true if had migrations pending, otherwise false.</returns>


### PR DESCRIPTION
Initial idea for allowing seed methods to be run explicitly. #26 

Based on how EF is set up, we have to run a migration in order for the seed method to get fired off. I figured sending in the current migration is probably the safest way to do this.

Questions:
1. Any concerns about this method in general? There is a risk of crashing if the current migration is empty - which could only happen if there are no migrations on the database.
2. Any ideas on the best way to test this? I'm not sure what exactly would need to be tested, based on how this was implemented.