### PR TITLE
Upgrade Cake to 0.32.1

### DIFF
--- a/src/Cake.EntityFramework.Tests/Cake.EntityFramework.Tests.csproj
+++ b/src/Cake.EntityFramework.Tests/Cake.EntityFramework.Tests.csproj
@@ -39,8 +39,8 @@
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.23.0\lib\net46\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.32.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.32.1\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="Cake.Testing">
       <HintPath>..\packages\Cake.Testing.0.22.0\lib\net46\Cake.Testing.dll</HintPath>
@@ -61,6 +61,7 @@
     <Reference Include="FluentAssertions.Core, Version=4.19.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.19.2\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Npgsql, Version=3.2.2.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.3.2.2\lib\net451\Npgsql.dll</HintPath>
     </Reference>

--- a/src/Cake.EntityFramework.Tests/Fixtures/CakeContextFixture.cs
+++ b/src/Cake.EntityFramework.Tests/Fixtures/CakeContextFixture.cs
@@ -19,11 +19,12 @@ namespace Cake.EntityFramework.Tests.Fixtures
         public IProcessRunner ProcessRunner { get; set; }
         public IRegistry Registry { get; set; }
         public IToolLocator Tools { get; set; }
+        public ICakeDataResolver Data { get; }
 
         public CakeContextFixture()
         {
             var cakeRuntime = Substitute.For<ICakeRuntime>();
-            cakeRuntime.TargetFramework.Returns(new FrameworkName(".NET Framework", new Version(4, 5, 2)));
+            cakeRuntime.BuiltFramework.Returns(new FrameworkName(".NET Framework", new Version(4, 5, 2)));
             cakeRuntime.CakeVersion.Returns(typeof(ICakeRuntime).Assembly.GetName().Version);
 
             FileSystem = Substitute.For<IFileSystem>();
@@ -36,7 +37,7 @@ namespace Cake.EntityFramework.Tests.Fixtures
             ProcessRunner = Substitute.For<IProcessRunner>();
             Registry = Substitute.For<IRegistry>();
             Tools = Substitute.For<IToolLocator>();
-
+            Data = Substitute.For<ICakeDataResolver>();
         }
 
         public void Dispose()

--- a/src/Cake.EntityFramework.Tests/packages.config
+++ b/src/Cake.EntityFramework.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="3.50.2" targetFramework="net461" />
-  <package id="Cake.Core" version="0.23.0" targetFramework="net461" />
+  <package id="Cake.Core" version="0.32.1" targetFramework="net461" />
   <package id="Cake.Testing" version="0.22.0" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="EntityFramework6.Npgsql" version="3.1.1" targetFramework="net461" />

--- a/src/Cake.EntityFramework/Cake.EntityFramework.csproj
+++ b/src/Cake.EntityFramework/Cake.EntityFramework.csproj
@@ -35,8 +35,8 @@
     <DocumentationFile>Cake.EntityFramework.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.23.0\lib\net46\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.32.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.32.1\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>

--- a/src/Cake.EntityFramework/packages.config
+++ b/src/Cake.EntityFramework/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.23.0" targetFramework="net46" />
+  <package id="Cake.Core" version="0.32.1" targetFramework="net46" />
   <package id="Costura.Fody" version="1.3.3.0" targetFramework="net452" developmentDependency="true" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net46" />
   <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.23.0" />
+	<package id="Cake" version="0.32.1" />
 </packages>


### PR DESCRIPTION
Hi @louisfischer ,
I needed to upgrade Cake.Core to avoid using --settings_skipverification=true. Please let me know if we can merge and release.