### PR TITLE
Deprecating Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Cake.EntityFramework
+# Cake.EntityFramework (DEPRECATED)
+
+## DEPRECATED 
+> This library is deprecated and not being maintained anymore.  
+> Please use [Cake.EntityFramework6](https://github.com/cake-contrib/Cake.EntityFramework6) instead.
+
 
 A set of Cake aliases for Entity Framework code-first migrations.
 

--- a/nuspec/nuget/Cake.EntityFramework.nuspec
+++ b/nuspec/nuget/Cake.EntityFramework.nuspec
@@ -5,7 +5,7 @@
     <version>0.0.0</version>
     <authors>Silvenga,louisfischer</authors>
     <owners>Silvenga,louisfischer,cake-contrib</owners>
-    <title>Cake.EntityFramework</title>
+    <title>Cake.EntityFramework (DEPRECATED)</title>
     <description>A set of Cake aliases for Entity Framework code-first migrations.</description>
     <summary>Entity Framework 6x addin for cake build.</summary>
     <license type="expression">MIT</license>


### PR DESCRIPTION
Deprecating Package. Use [Cake.EntityFramework6](https://github.com/cake-contrib/Cake.EntityFramework6) instead